### PR TITLE
fix: org-export-collect-footnote-definitions call

### DIFF
--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -84,7 +84,8 @@ definitions at the end."
    contents
    "\n\n"
    (let ((definitions (org-export-collect-footnote-definitions
-                       (plist-get info :parse-tree) info)))
+		       info
+                       (plist-get info :parse-tree))))
      ;; Looks like leanpub do not like : in labels.
      (mapconcat (lambda (ref)
                   (let ((id (format "[^%s]: " (replace-regexp-in-string

--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -20,7 +20,7 @@
 ;;; Define Back-End
 
 (org-export-define-derived-backend 'leanpub 'md
-  :export-block '("leanpub" "LEANPUB")
+;;  :export-block '("leanpub" "LEANPUB")
   :menu-entry
   '(?L "Export to Leanpub Markdown"
        ((?L "To temporary buffer"


### PR DESCRIPTION
Error message: Wrong type argument: sequencep, :input-buffer

Cause: The function org-export-collect-footnote-definitions had a signature change.

More explanation on the changes can be found here: http://orgmode.org/Changes_old.html