### PR TITLE
Multiple improvements

### DIFF
--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -54,6 +54,8 @@
                      (latex-fragment . org-leanpub-latex-fragment)
                      (line-break . org-leanpub-line-break)
                      (table . org-leanpub-table)
+                     (table-cell . org-leanpub-table-cell)
+                     (table-row . org-leanpub-table-row)
                      ;; Will not work with leanpub:
                      (export-block . org-leanpub-ignore)))
 
@@ -95,6 +97,12 @@
        output
        (unless nonewline "\n")))))
 
+(defun chomp-end (str)
+  "Chomp tailing whitespace from STR."
+  (replace-regexp-in-string (rx (* (any " \t\n")) eos)
+                            ""
+                            str))
+
 (defun org-leanpub-table (table contents info)
   "Transcode a table object from Org to Markdown.
 CONTENTS is nil.  INFO is a plist holding contextual information.
@@ -108,9 +116,13 @@ Add an #+attr_leanpub: line right before the table with the formatting info that
 "
   (concat
    (org-leanpub-attribute-line table info)
-   (buffer-substring (org-element-property :contents-begin table)
-                                               (org-element-property :contents-end table))))
+   (replace-regexp-in-string "^\s*\n" "" (org-export-data (org-element-contents table) info))))
 
+(defun org-leanpub-table-row (table-row contents info)
+  (format "| %s" (org-export-data contents info)))
+
+(defun org-leanpub-table-cell (table-cell contents info)
+  (format " %s |" (org-export-data contents info)))
 
 (defun org-leanpub-latex-fragment (latex-fragment contents info)
   "Transcode a LATEX-FRAGMENT object from Org to Markdown.
@@ -276,9 +288,7 @@ channel."
       "^" (concat lp-char "> ")
       (concat
        (when (> (length caption) 0) (format "### %s\n" caption))
-       (replace-regexp-in-string (rx (* (any " \t\n")) eos)
-                                 ""
-                                 (org-remove-indentation contents)))))))
+       (chomp-end (org-remove-indentation contents)))))))
 
 (defun org-leanpub-link (link contents info)
   "Transcode a link object into Markdown format.

--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -68,13 +68,54 @@ CONTENTS is nil.  INFO is a plist holding contextual information."
            "\\\\\\[\\|\\\\\\]\\|\\$" ""
            (org-element-property :value latex-fragment))))
 
+(defun org-md-headline-without-anchor (headline contents info)
+  "Transcode HEADLINE element into Markdown format.
+CONTENTS is the headline contents.  INFO is a plist used as
+a communication channel. This is the same function as
+org-md-headline but without inserting the <a> anchors."
+  (unless (org-element-property :footnote-section-p headline)
+    (let* ((level (org-export-get-relative-level headline info))
+	   (title (org-export-data (org-element-property :title headline) info))
+	   (todo (and (plist-get info :with-todo-keywords)
+		      (let ((todo (org-element-property :todo-keyword
+							headline)))
+			(and todo (concat (org-export-data todo info) " ")))))
+	   (tags (and (plist-get info :with-tags)
+		      (let ((tag-list (org-export-get-tags headline info)))
+			(and tag-list
+			     (concat "     " (org-make-tag-string tag-list))))))
+	   (priority
+	    (and (plist-get info :with-priority)
+		 (let ((char (org-element-property :priority headline)))
+		   (and char (format "[#%c] " char)))))
+	   ;; Headline text without tags.
+	   (heading (concat todo priority title))
+	   (style (plist-get info :md-headline-style)))
+      (cond
+       ;; Cannot create a headline.  Fall-back to a list.
+       ((or (org-export-low-level-p headline info)
+	    (not (memq style '(atx setext)))
+	    (and (eq style 'atx) (> level 6))
+	    (and (eq style 'setext) (> level 2)))
+	(let ((bullet
+	       (if (not (org-export-numbered-headline-p headline info)) "-"
+		 (concat (number-to-string
+			  (car (last (org-export-get-headline-number
+				      headline info))))
+			 "."))))
+	  (concat bullet (make-string (- 4 (length bullet)) ?\s) heading tags "\n\n"
+		  (and contents (replace-regexp-in-string "^" "    " contents)))))
+       (t
+	(concat (org-md--headline-title style level heading nil tags)
+		        contents))))))
+
 ;;; Adding the id so that crosslinks work.
 (defun org-leanpub-headline (headline contents info)
-  (concat (let ((id (org-element-property :ID headline)))
+  (concat (let ((id (or (org-element-property :ID headline) (org-element-property :CUSTOM_ID headline))))
             (if id
-                (format "{#L%s}\n" id)
+                (format "{#L%s}" id)
               ""))
-          (org-md-headline headline contents info)))
+          (org-md-headline-without-anchor headline contents info)))
 
 (defun org-leanpub-inner-template (contents info)
   "Return complete document string after markdown conversion.

--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -166,25 +166,26 @@ definitions at the end."
   "Transcode SRC-BLOCK element into Markdown format.
 CONTENTS is nil.  INFO is a plist used as a communication
 channel."
-  (let ((lang (org-element-property :language src-block)))
-    (format "{lang=\"%s\"}\n~~~~~~~~\n%s~~~~~~~~"
+  (let ((lang (org-element-property :language src-block))
+        (linenos (org-element-property :number-lines src-block)))
+    (format "{lang=\"%s\"%s}\n~~~~~~~~\n%s~~~~~~~~"
             lang
+            (if linenos ",linenos=on" "")
             (org-remove-indentation
              (org-element-property :value src-block)))))
 
-;;; A> {linenos=off}
-;;; A> ~~~~~~~~
-;;; A> 123.0
-;;; A> ~~~~~~~~
+;;; > ~~~~~~~~
+;;; > 123.0
+;;; > ~~~~~~~~
 (defun org-leanpub-fixed-width-block (src-block contents info)
   "Transcode FIXED-WIDTH-BLOCK element into Markdown format.
 CONTENTS is nil.  INFO is a plist used as a communication
 channel."
-  (replace-regexp-in-string
-   "^" "A> "
-   (format "{linenos=off}\n~~~~~~~~\n%s~~~~~~~~"
-           (org-remove-indentation
-            (org-element-property :value src-block)))))
+  (let ((linenos (org-element-property :number-lines src-block)))
+    (format "%s~~~~~~~~\n%s~~~~~~~~"
+            (if linenos "{linenos=on}\n" "")
+            (org-remove-indentation
+             (org-element-property :value src-block)))))
 
 ;;; Export special blocks, mapping them to corresponding block types according to the LeanPub documentation at https://leanpub.com/help/manual#leanpub-auto-blocks-of-text.
 ;;; The supported block types and their conversions are listed in lp-block-mappings.

--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -32,6 +32,7 @@
 		(org-open-file (org-leanpub-export-to-markdown nil s v)))))))
   :translate-alist '((fixed-width . org-leanpub-fixed-width-block)
                      (example-block . org-leanpub-fixed-width-block)
+                     (special-block . org-leanpub-special-block)
                      (src-block . org-leanpub-src-block)
                      (plain-text . org-leanpub-plain-text)
                      (inner-template . org-leanpub-inner-template)
@@ -41,7 +42,7 @@
                      (latex-fragment . org-leanpub-latex-fragment)
                      (table . org-leanpub-table)
                      ;; Will not work with leanpub:
-                     (export-block . org-leanpub-ignore))) ; #+html
+                     (export-block . org-leanpub-ignore)))
 
 (defun org-leanpub-table (table contents info)
   "Transcode a table object from Org to Markdown.
@@ -143,6 +144,34 @@ channel."
    (format "{linenos=off}\n~~~~~~~~\n%s~~~~~~~~"
            (org-remove-indentation
             (org-element-property :value src-block)))))
+
+;;; Export special blocks, mapping them to corresponding block types according to the LeanPub documentation at https://leanpub.com/help/manual#leanpub-auto-blocks-of-text.
+;;; The supported block types and their conversions are listed in lp-block-mappings.
+;;; e.g.
+;;;     #+begin_tip
+;;;     This is a tip
+;;;     #+end_tip
+;;; gets exported as
+;;;     T> This is a tip
+(defun org-leanpub-special-block (special-block contents info)
+  "Transcode a SPECIAL-BLOCK element into Markdown format.
+CONTENTS is nil.  INFO is a plist used as a communication
+channel."
+  (let* ((type (org-element-property :type special-block))
+         (lp-block-mappings
+          '(tip "T"
+            aside "A"
+            warning "W"
+            error "E"
+            note "I"
+            question "Q"
+            discussion "D"
+            exercise "X"
+            center "C"))
+         (lp-char (plist-get lp-block-mappings (intern type))))
+    (replace-regexp-in-string
+     "^" (concat lp-char "> ")
+     (org-remove-indentation contents))))
 
 (defun org-leanpub-link (link contents info)
   "Transcode a link object into Markdown format.

--- a/ox-leanpub.el
+++ b/ox-leanpub.el
@@ -20,7 +20,7 @@
 ;;; Define Back-End
 
 (org-export-define-derived-backend 'leanpub 'md
-  :export-block '("leanpub" "LEANPUB")
+;;  :export-block '("leanpub" "LEANPUB")
   :menu-entry
   '(?L "Export to Leanpub Markdown"
        ((?L "To temporary buffer"
@@ -84,7 +84,8 @@ definitions at the end."
    contents
    "\n\n"
    (let ((definitions (org-export-collect-footnote-definitions
-                       (plist-get info :parse-tree) info)))
+		                   info
+                       (plist-get info :parse-tree))))
      ;; Looks like leanpub do not like : in labels.
      (mapconcat (lambda (ref)
                   (let ((id (format "[^%s]: " (replace-regexp-in-string


### PR DESCRIPTION
This pull request has grown as I have worked on ox-leanpub, and now includes several changes:

**Consistent handling of attributes**

- The `#+NAME` and `#+CAPTION` of an object, if specified, are converted
  to the correct "id" and "title" attributes in LeanPub format. Other
  attributes can be specified in the #+ATTR_LEANPUB line, in
  header-argument format, and included in the attributes line as-is. For example:

      #+NAME: some-id
      #+CAPTION: Some name
      #+ATTR_LEANPUB: :width wide

  Get converted to the following line, included before the corresponding element:

      {id="some-id", title="Some name", width="wide"}

  These attributes are now handled consistently for tables, figures,
  special boxes, src and example blocks, and headlines.

- For SRC blocks, if the -n option is used to enable line numbering,
  then the "linenos=on" attribute is included. Note that there is no
  facility in org to explicitly disable line numbering, so this only
  works if line numbering is disabled by default in the LeanPub
  project. If you have it enabled and want to disable line numbering
  in some blocks, you can use the following:

      #+ATTR_LEANPUB: :linenos off

- If an old-style `#+ATTR_LEANPUB` is used, enclosed in curly braces (as
  they were allowed in previous versions, but only for tables), it is
  used as-is, but other attributes (e.g. `#+NAME`) do not get included.

**Special blocks**

Export special blocks, mapping them to corresponding block types according to the LeanPub documentation at https://leanpub.com/help/manual#leanpub-auto-blocks-of-text.

The supported block types and their LeanPub character mappings are:

tip "T"
aside "A"
warning "W"
error "E"
note "I"
question "Q"
discussion "D"
exercise "X"
center "C"

As an example:

    #+begin_tip
    This is a tip
    #+end_tip

gets exported as

    T> This is a tip

**Example blocks are not wrapped by default in an aside**

Example blocks are not marked as an "aside" block ("A>"), only  typeset in fixed width. To create a fixed-width aside, you can use an "example" block inside an "aside" block.

**Handling of -n flag for line numbering**

Both src and example blocks now understand the -n flag to enable  line numbering, adding the "linenos=on" attribute to the  output. NOTE: This assumes line numbering is disabled by default in  the LeanPub project configuration, as there is no syntax (yet) to  specify "linenos=off".

**Headline formatting fixes**

Remove HTML <a> tag which was being generated by the ox-md exporter,
and remove the blank line between the Leanpub Markdown ID line and the
headline itself (which broke formatting).

Also allow both the ID and CUSTOM_ID properties to specify the
headline ID.

**Function signature changes in new org-mode versions**

Also includes the function signature fix from #2 
